### PR TITLE
Fixed hang issue when search icon not loaded

### DIFF
--- a/Framework/src/MZSearchProviderPlugin.m
+++ b/Framework/src/MZSearchProviderPlugin.m
@@ -93,6 +93,12 @@
         if(!iconURL)
             return nil;
         icon = [[NSImage alloc] initWithContentsOfURL:iconURL];
+		if (!icon)
+		{
+			// We couldn't load the required icon. Fallback to a warning icon.
+			icon = [[[NSWorkspace sharedWorkspace]
+					 iconForFileType:NSFileTypeForHFSTypeCode(kAlertCautionIcon)] retain];
+		}
     }
     return icon;
 }


### PR DESCRIPTION
If, during the loading of the icon for the search provider
the icon couldn't be loaded (eg. download timeout)
the system would hang after loading the search results
because each time the result table would go to display
a result it would attempt to reload the icon from the
search provider.  In the case (well, for me anyway)
themoviedb/favicon.ico would timeout when loading
every time I attempted to interact with the loaded list
it would attempt a re-load of the icon.

This could be smarter (e.g. after the current operation
queue has completed reset the icon to blank and attempt
a reload) however in its current form it solves a problem